### PR TITLE
feat: Support isolated nested state via StateScopeProvider

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -105,27 +105,6 @@ import 'react-state-custom/dist/react-state-custom.css';
 
 ---
 
-## 🎭 State Isolation
-
-### `StateScopeProvider`
-
-A component that creates an isolated state scope for its children. All stores accessed within this provider will be independent of the global scope or parent scopes.
-
-```typescript
-function StateScopeProvider(props: {
-  children: React.ReactNode;
-}): JSX.Element
-```
-
-#### Example
-```tsx
-<StateScopeProvider>
-  <YourIsolatedComponent />
-</StateScopeProvider>
-```
-
----
-
 ## ⚙️ Advanced API (Primitives)
 
 These APIs are used internally by `createStore`. You generally don't need them unless you're building custom abstractions.

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -105,6 +105,27 @@ import 'react-state-custom/dist/react-state-custom.css';
 
 ---
 
+## 🎭 State Isolation
+
+### `StateScopeProvider`
+
+A component that creates an isolated state scope for its children. All stores accessed within this provider will be independent of the global scope or parent scopes.
+
+```typescript
+function StateScopeProvider(props: {
+  children: React.ReactNode;
+}): JSX.Element
+```
+
+#### Example
+```tsx
+<StateScopeProvider>
+  <YourIsolatedComponent />
+</StateScopeProvider>
+```
+
+---
+
 ## ⚙️ Advanced API (Primitives)
 
 These APIs are used internally by `createStore`. You generally don't need them unless you're building custom abstractions.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,30 @@ export default function App() {
 }
 ```
 
+### 🎭 Isolated State
+
+Need to run multiple independent instances of your application or isolate features? Use `StateScopeProvider`.
+
+```tsx
+import { AutoRootCtx, StateScopeProvider } from 'react-state-custom'
+
+function App() {
+  return (
+    <>
+      <AutoRootCtx /> {/* Global Scope */}
+      <MainApp />
+
+      <StateScopeProvider>
+         {/* Isolated Scope - Stores here are independent of Global Scope */}
+         <IsolatedFeature />
+      </StateScopeProvider>
+    </>
+  )
+}
+```
+
+Stores used inside `StateScopeProvider` will be completely isolated from the parent or global scope, even if they share the same store definition.
+
 ---
 
 ## 🆚 Comparison

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export {
 } from "./state-utils/ctx"
 
 export { createRootCtx } from "./state-utils/createRootCtx"
-export { AutoRootCtx, createAutoCtx, createStore } from "./state-utils/createAutoCtx"
+export { AutoRootCtx, createAutoCtx, createStore, StateScopeProvider } from "./state-utils/createAutoCtx"
 export { useArrayChangeId } from "./state-utils/useArrayChangeId"
 export { paramsToId, type ParamsToIdRecord, type ParamsToIdInput } from "./state-utils/paramsToId"
 

--- a/src/state-utils/createAutoCtx.tsx
+++ b/src/state-utils/createAutoCtx.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, Fragment, useCallback, useMemo, Activity } from "react"
-import { useDataContext, useDataSourceMultiple, useDataSubscribe, type Context } from "./ctx"
+import { useEffect, useState, Fragment, useCallback, useMemo, Activity, useId } from "react"
+import { useDataContext, useDataSourceMultiple, useDataSubscribe, StateScopeContext, type Context } from "./ctx"
 import { createRootCtx } from "./createRootCtx"
 import { paramsToId, type ParamsToIdRecord } from "./paramsToId"
 import { useQuickSubscribe } from "./useQuickSubscribe"
@@ -182,4 +182,12 @@ export const createStore = <U extends ParamsToIdRecord, V extends Record<string,
   AttatchedComponent: React.FC<U> | undefined = undefined
 ) => {
   return createAutoCtx(createRootCtx(name, useFn), timeToClean, AttatchedComponent)
+}
+
+export const StateScopeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const scopeId = useId()
+  return <StateScopeContext.Provider value={scopeId}>
+    <AutoRootCtx />
+    {children}
+  </StateScopeContext.Provider>
 }

--- a/src/state-utils/createAutoCtx.tsx
+++ b/src/state-utils/createAutoCtx.tsx
@@ -184,10 +184,14 @@ export const createStore = <U extends ParamsToIdRecord, V extends Record<string,
   return createAutoCtx(createRootCtx(name, useFn), timeToClean, AttatchedComponent)
 }
 
-export const StateScopeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export const StateScopeProvider: React.FC<{
+  children: React.ReactNode
+  Wrapper?: React.FC<any>
+  debugging?: boolean
+}> = ({ children, Wrapper, debugging }) => {
   const scopeId = useId()
   return <StateScopeContext.Provider value={scopeId}>
-    <AutoRootCtx />
+    <AutoRootCtx Wrapper={Wrapper} debugging={debugging} />
     {children}
   </StateScopeContext.Provider>
 }

--- a/src/state-utils/createAutoCtx.tsx
+++ b/src/state-utils/createAutoCtx.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, Fragment, useCallback, useMemo, Activity, useId } from "react"
+import { useEffect, useState, Fragment, useCallback, useMemo, useId } from "react"
 import { useDataContext, useDataSourceMultiple, useDataSubscribe, StateScopeContext, type Context } from "./ctx"
 import { createRootCtx } from "./createRootCtx"
 import { paramsToId, type ParamsToIdRecord } from "./paramsToId"

--- a/tests/createAutoCtx.nested.test.tsx
+++ b/tests/createAutoCtx.nested.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
-import React, { useId } from 'react'
+import React from 'react'
 import { createAutoCtx, AutoRootCtx, StateScopeProvider } from '../src/state-utils/createAutoCtx'
 import { createRootCtx } from '../src/state-utils/createRootCtx'
 import { useDataSubscribe } from '../src/state-utils/ctx'

--- a/tests/createAutoCtx.nested.test.tsx
+++ b/tests/createAutoCtx.nested.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import React, { useId } from 'react'
+import { createAutoCtx, AutoRootCtx, StateScopeProvider } from '../src/state-utils/createAutoCtx'
+import { createRootCtx } from '../src/state-utils/createRootCtx'
+import { useDataSubscribe } from '../src/state-utils/ctx'
+
+describe('AutoRootCtx Isolation', () => {
+  it('should isolate state between nested scopes', async () => {
+    // Create a simple counter store
+    const useCounter = () => {
+      const [count, setCount] = React.useState(0)
+      return {
+        count,
+        increment: () => setCount(c => c + 1)
+      }
+    }
+
+    const rootCtx = createRootCtx('isolation-test', useCounter)
+    const autoCtx = createAutoCtx(rootCtx)
+
+    function Consumer({ label }: { label: string }) {
+      const ctx = autoCtx.useCtxState({})
+      const count = useDataSubscribe(ctx, 'count')
+      const increment = useDataSubscribe(ctx, 'increment')
+
+      return (
+        <div data-testid={`consumer-${label}`}>
+          <span data-testid={`count-${label}`}>{count}</span>
+          <button onClick={increment} data-testid={`btn-${label}`}>
+            Increment
+          </button>
+        </div>
+      )
+    }
+
+    render(
+      <>
+        <AutoRootCtx />
+        <Consumer label="outer" />
+
+        <StateScopeProvider>
+           <Consumer label="inner" />
+        </StateScopeProvider>
+      </>
+    )
+
+    // Initial state: both should be 0
+    await waitFor(() => {
+      expect(screen.getByTestId('count-outer').textContent).toBe('0')
+      expect(screen.getByTestId('count-inner').textContent).toBe('0')
+    })
+
+    // Increment outer
+    fireEvent.click(screen.getByTestId('btn-outer'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('count-outer').textContent).toBe('1')
+      // Inner should remain 0 if isolated
+      expect(screen.getByTestId('count-inner').textContent).toBe('0')
+    })
+
+    // Increment inner
+    fireEvent.click(screen.getByTestId('btn-inner'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('count-outer').textContent).toBe('1')
+      expect(screen.getByTestId('count-inner').textContent).toBe('1')
+    })
+  })
+})


### PR DESCRIPTION
This PR introduces the `StateScopeProvider` component, allowing developers to create isolated state scopes within their React application.

**Key Changes:**
1.  **`StateScopeProvider`**: A new component that generates a unique scope ID (via `useId`) and provides it to its children via `StateScopeContext`. It also renders an internal `AutoRootCtx` to manage the roots for that specific scope.
2.  **Scope-Aware `useDataContext`**: The `useDataContext` hook now reads the current `StateScopeContext`. If a scope ID is present, it prefixes the context name (e.g., `":r1:/my-store"`), ensuring data isolation.
3.  **Duplicate Mount Check**: The `createRootCtx` factory now includes the scope ID when checking for duplicate root mounts, preventing false positives when the same store is used in different scopes.

**Usage:**
```jsx
<AutoRootCtx>
  {/* Global Scope */}
  <App />
  
  <StateScopeProvider>
     {/* Isolated Scope - Stores here are independent of Global Scope */}
     <Feature />
  </StateScopeProvider>
</AutoRootCtx>
```

**Testing:**
- Added `tests/createAutoCtx.nested.test.tsx` which confirms that state updates in an outer scope do not affect the inner scope and vice-versa.
- Validated that existing global state behavior remains unchanged.


---
*PR created automatically by Jules for task [12691107722258462697](https://jules.google.com/task/12691107722258462697) started by @quynhtrang0309*